### PR TITLE
feat: issue login jwt instead of session

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Create a `.env.local` file in the root directory:
 ```env
 NEXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key
+AUTH_JWT_SECRET=your_custom_login_token_secret
 ```
 
 ## 📜 Available Scripts

--- a/src/app/api/v1/auth/login/route.ts
+++ b/src/app/api/v1/auth/login/route.ts
@@ -1,0 +1,69 @@
+import { createHmac } from "node:crypto";
+import { NextRequest, NextResponse } from "next/server";
+
+const TOKEN_EXPIRATION_SECONDS = 60 * 60; // 1 hour
+
+const base64UrlEncode = (value: string | Buffer) =>
+  Buffer.from(value)
+    .toString("base64")
+    .replace(/=/g, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_");
+
+const createJwtToken = (payload: Record<string, unknown>, secret: string) => {
+  const header = {
+    alg: "HS256",
+    typ: "JWT",
+  };
+
+  const encodedHeader = base64UrlEncode(JSON.stringify(header));
+  const encodedPayload = base64UrlEncode(JSON.stringify(payload));
+  const data = `${encodedHeader}.${encodedPayload}`;
+  const signature = base64UrlEncode(createHmac("sha256", secret).update(data).digest());
+
+  return `${data}.${signature}`;
+};
+
+export async function POST(request: NextRequest) {
+  const secret = process.env.AUTH_JWT_SECRET;
+
+  if (!secret) {
+    return NextResponse.json(
+      { error: "AUTH_JWT_SECRET is not configured" },
+      { status: 500 }
+    );
+  }
+
+  let body: { userId?: unknown; email?: unknown };
+  try {
+    body = await request.json();
+  } catch (error) {
+    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
+  }
+
+  const userId = typeof body.userId === "string" ? body.userId.trim() : "";
+  const email = typeof body.email === "string" ? body.email.trim() : "";
+
+  if (!userId) {
+    return NextResponse.json({ error: "userId is required" }, { status: 400 });
+  }
+
+  const issuedAt = Math.floor(Date.now() / 1000);
+  const payload: Record<string, unknown> = {
+    sub: userId,
+    iat: issuedAt,
+    exp: issuedAt + TOKEN_EXPIRATION_SECONDS,
+  };
+
+  if (email) {
+    payload.email = email;
+  }
+
+  try {
+    const token = createJwtToken(payload, secret);
+    return NextResponse.json({ token });
+  } catch (error) {
+    console.error("Failed to create login token:", error);
+    return NextResponse.json({ error: "Unable to generate login token" }, { status: 500 });
+  }
+}

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -1,21 +1,96 @@
 "use client";
 
-import { createContext, useContext, useEffect, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { User } from "@supabase/supabase-js";
 import { supabase } from "./supabaseClients";
 
 interface AuthContextType {
   user: User | null;
   loading: boolean;
+  loginToken: string | null;
   signOut: () => Promise<void>;
   getUserCredits: (userId: string) => Promise<number>;
+  refreshLoginToken: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
+const TOKEN_STORAGE_KEY = "eswap.loginToken";
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null);
+  const [loginToken, setLoginToken] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
+
+  const persistToken = useCallback((token: string | null) => {
+    setLoginToken(token);
+
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    if (token) {
+      window.localStorage.setItem(TOKEN_STORAGE_KEY, token);
+    } else {
+      window.localStorage.removeItem(TOKEN_STORAGE_KEY);
+    }
+  }, []);
+
+  const createLoginToken = useCallback(
+    async (currentUser: User) => {
+      try {
+        const response = await fetch("/api/v1/auth/login", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            userId: currentUser.id,
+            email: currentUser.email ?? undefined,
+          }),
+        });
+
+        if (!response.ok) {
+          throw new Error(`Failed to create login token: ${response.status}`);
+        }
+
+        const data = (await response.json()) as { token?: string };
+
+        if (!data.token || typeof data.token !== "string") {
+          throw new Error("Invalid login token response");
+        }
+
+        persistToken(data.token);
+      } catch (error) {
+        console.error("Failed to create login token:", error);
+        persistToken(null);
+      }
+    },
+    [persistToken]
+  );
+
+  const handleUserStateChange = useCallback(
+    async (currentUser: User | null) => {
+      setUser(currentUser);
+
+      if (currentUser) {
+        await createLoginToken(currentUser);
+      } else {
+        persistToken(null);
+      }
+    },
+    [createLoginToken, persistToken]
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const storedToken = window.localStorage.getItem(TOKEN_STORAGE_KEY);
+    if (storedToken) {
+      setLoginToken(storedToken);
+    }
+  }, []);
 
   useEffect(() => {
     // Get initial session
@@ -24,10 +99,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         const {
           data: { session },
         } = await supabase.auth.getSession();
-        setUser(session?.user ?? null);
+        await handleUserStateChange(session?.user ?? null);
       } catch (error) {
         console.error("Failed to get initial session:", error);
         setUser(null);
+        persistToken(null);
       } finally {
         setLoading(false);
       }
@@ -38,17 +114,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     // Listen for auth changes
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange(async (event, session) => {
-      setUser(session?.user ?? null);
+    } = supabase.auth.onAuthStateChange(async (_event, session) => {
+      await handleUserStateChange(session?.user ?? null);
       setLoading(false);
     });
 
     return () => subscription.unsubscribe();
-  }, []);
+  }, [handleUserStateChange, persistToken]);
 
   const signOut = async () => {
     try {
       await supabase.auth.signOut();
+      persistToken(null);
+      setUser(null);
     } catch (error) {
       console.error("Failed to sign out:", error);
       throw error; // Re-throw to allow caller to handle
@@ -61,7 +139,14 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       return 0;
     }
     try {
-      const response = await fetch(`/api/v1/users/${userId}/credits`);
+      const headers: Record<string, string> = {};
+      if (loginToken) {
+        headers.Authorization = `Bearer ${loginToken}`;
+      }
+
+      const response = await fetch(`/api/v1/users/${userId}/credits`, {
+        headers,
+      });
 
       if (!response.ok) {
         console.error(`Failed to fetch user credits: ${response.status} ${response.statusText}`);
@@ -76,8 +161,19 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const refreshLoginToken = useCallback(async () => {
+    if (!user) {
+      persistToken(null);
+      return;
+    }
+
+    await createLoginToken(user);
+  }, [createLoginToken, persistToken, user]);
+
   return (
-    <AuthContext.Provider value={{ user, loading, signOut, getUserCredits }}>
+    <AuthContext.Provider
+      value={{ user, loading, loginToken, signOut, getUserCredits, refreshLoginToken }}
+    >
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- add an API route that signs login JWTs on demand using a configured secret
- update the auth context to request, persist, and expose the login token for client use
- document the new AUTH_JWT_SECRET environment variable required for token generation

## Testing
- npm run lint *(fails: cannot find package '@eslint/eslintrc' in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e65a5629c4832fb2c94be03a1e270e